### PR TITLE
[FEAT] User, RefreshToken 컨트롤러 단위 테스트 추가

### DIFF
--- a/src/main/java/com/prgrms/team03linkbookbe/bookmark/controller/BookmarkController.java
+++ b/src/main/java/com/prgrms/team03linkbookbe/bookmark/controller/BookmarkController.java
@@ -6,6 +6,7 @@ import com.prgrms.team03linkbookbe.user.entity.User;
 import javax.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -38,7 +39,7 @@ public class BookmarkController {
         bookmarkService.update(user.getId(), id, bookmarkRequest);
     }
 
-    @PutMapping("/api/bookmarks/{id}")
+    @DeleteMapping("/api/bookmarks/{id}")
     @ResponseStatus(HttpStatus.OK)
     public void delete(@PathVariable Long id,
         @AuthenticationPrincipal User user) {

--- a/src/main/java/com/prgrms/team03linkbookbe/folder/entity/Folder.java
+++ b/src/main/java/com/prgrms/team03linkbookbe/folder/entity/Folder.java
@@ -69,12 +69,15 @@ public class Folder extends BaseDateEntity {
     @JoinColumn(name = "users_id", referencedColumnName = "id")
     private User user;
 
+    @Builder.Default
     @OneToMany(mappedBy = "folder")
     private List<Bookmark> bookmarks = new ArrayList<>();
 
+    @Builder.Default
     @OneToMany(mappedBy = "folder")
     private List<Comment> comments = new ArrayList<>();
 
+    @Builder.Default
     @OneToMany(mappedBy = "folder")
     private List<FolderTag> folderTags = new ArrayList<>();
 

--- a/src/main/java/com/prgrms/team03linkbookbe/jwt/JwtAuthenticationToken.java
+++ b/src/main/java/com/prgrms/team03linkbookbe/jwt/JwtAuthenticationToken.java
@@ -20,7 +20,7 @@ public class JwtAuthenticationToken extends AbstractAuthenticationToken {
         this.credentials = credentials;
     }
 
-    JwtAuthenticationToken(Object principal, String credentials, Collection<? extends GrantedAuthority> authorities) {
+    public JwtAuthenticationToken(Object principal, String credentials, Collection<? extends GrantedAuthority> authorities) {
         super(authorities);
         super.setAuthenticated(true);
 

--- a/src/main/java/com/prgrms/team03linkbookbe/refreshtoken/controller/RefreshTokenController.java
+++ b/src/main/java/com/prgrms/team03linkbookbe/refreshtoken/controller/RefreshTokenController.java
@@ -1,12 +1,12 @@
 package com.prgrms.team03linkbookbe.refreshtoken.controller;
 
 
-import com.prgrms.team03linkbookbe.config.JwtConfigure;
 import com.prgrms.team03linkbookbe.refreshtoken.dto.AccessTokenResponseDto;
 import com.prgrms.team03linkbookbe.refreshtoken.service.RefreshTokenService;
-import javax.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
@@ -18,9 +18,13 @@ public class RefreshTokenController {
 
     private final RefreshTokenService refreshTokenService;
 
-    @PostMapping("/api/refresh-token")
-    public AccessTokenResponseDto reissueAccessTokenByRefreshToken (@RequestHeader(value = "Access-Token") String accessToken, @RequestHeader(value = "Refresh-Token") String refreshToken) {
-        return refreshTokenService.reissueAccessToken(accessToken, refreshToken);
+    @GetMapping("/api/refresh-token")
+    public ResponseEntity<AccessTokenResponseDto> reissueAccessTokenByRefreshToken(
+        @RequestHeader(value = "Access-Token") String accessToken,
+        @RequestHeader(value = "Refresh-Token") String refreshToken
+    ) {
+        AccessTokenResponseDto responseDto =
+            refreshTokenService.reissueAccessToken(accessToken, refreshToken);
+        return ResponseEntity.ok().body(responseDto);
     }
-
 }

--- a/src/main/java/com/prgrms/team03linkbookbe/refreshtoken/service/RefreshTokenService.java
+++ b/src/main/java/com/prgrms/team03linkbookbe/refreshtoken/service/RefreshTokenService.java
@@ -1,6 +1,5 @@
 package com.prgrms.team03linkbookbe.refreshtoken.service;
 
-import com.auth0.jwt.JWT;
 import com.auth0.jwt.exceptions.JWTVerificationException;
 import com.auth0.jwt.exceptions.TokenExpiredException;
 import com.auth0.jwt.interfaces.DecodedJWT;
@@ -44,10 +43,10 @@ public class RefreshTokenService {
 
             // refreshToken DB 검사
             User user = userRepository.findByEmail(claims.getEmail())
-                .orElseThrow(() -> new IllegalTokenException());
+                .orElseThrow(IllegalTokenException::new);
 
             RefreshToken findRefreshToken = refreshTokenRepository.findByUserId(user.getId())
-                .orElseThrow(() -> new IllegalTokenException());
+                .orElseThrow(IllegalTokenException::new);
 
             if (!findRefreshToken.getValue().equals(refreshToken)) {
                 throw new IllegalTokenException();
@@ -68,7 +67,7 @@ public class RefreshTokenService {
     public String issueRefreshToken(Claims claims) {
         String newRefreshToken = jwt.createRefreshToken(claims);
         User user = userRepository.findByEmail(claims.getEmail())
-            .orElseThrow(() -> new NoDataException());
+            .orElseThrow(NoDataException::new);
 
         refreshTokenRepository.findByUserId(user.getId())
             .ifPresentOrElse(
@@ -78,8 +77,8 @@ public class RefreshTokenService {
                 },
                 () -> {
                     refreshTokenRepository.save(RefreshToken.builder()
-                            .value(newRefreshToken)
-                            .user(user)
+                        .value(newRefreshToken)
+                        .user(user)
                         .build());
                     log.info("refreshToken create, email : {}", user.getEmail());
                 });

--- a/src/main/java/com/prgrms/team03linkbookbe/user/controller/UserController.java
+++ b/src/main/java/com/prgrms/team03linkbookbe/user/controller/UserController.java
@@ -32,7 +32,7 @@ public class UserController {
     private final AuthenticationManager authenticationManager;
 
     @GetMapping("/api/users/me")
-    public ResponseEntity<UserResponseDto> me (@AuthenticationPrincipal JwtAuthentication authentication) {
+    public ResponseEntity<UserResponseDto> me(@AuthenticationPrincipal JwtAuthentication authentication) {
         UserResponseDto responseDto = userService.findByEmail(authentication.email);
         return ResponseEntity.ok(responseDto);
     }

--- a/src/main/java/com/prgrms/team03linkbookbe/user/dto/LoginRequestDto.java
+++ b/src/main/java/com/prgrms/team03linkbookbe/user/dto/LoginRequestDto.java
@@ -1,6 +1,7 @@
 package com.prgrms.team03linkbookbe.user.dto;
 
 
+import javax.validation.constraints.Email;
 import javax.validation.constraints.NotBlank;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -15,6 +16,7 @@ import lombok.NoArgsConstructor;
 public class LoginRequestDto {
 
     @NotBlank(message = "Email cannot be blank")
+    @Email(message = "이메일 형식이 일치하지 않습니다.")
     private String email;
 
     @NotBlank(message = "Password cannot be blank")

--- a/src/main/java/com/prgrms/team03linkbookbe/user/dto/RegisterRequestDto.java
+++ b/src/main/java/com/prgrms/team03linkbookbe/user/dto/RegisterRequestDto.java
@@ -1,6 +1,7 @@
 package com.prgrms.team03linkbookbe.user.dto;
 
 import com.prgrms.team03linkbookbe.user.entity.User;
+import javax.validation.constraints.Email;
 import javax.validation.constraints.NotBlank;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -16,15 +17,20 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 public class RegisterRequestDto {
 
     @NotBlank(message = "Email cannot be blank")
+    @Email(message = "이메일 형식이 일치하지 않습니다.")
     private String email;
 
     @NotBlank(message = "Password cannot be blank")
     private String password;
 
+    @NotBlank(message = "Image URL cannot be blank")
+    private String image;
+
     public User toEntity(PasswordEncoder passwordEncoder) {
         return User.builder()
             .email(this.getEmail())
             .password(passwordEncoder.encode(password))
+            .image(image)
             .name("익명의사용자")
             .role("ROLE_USER")
             .build();

--- a/src/main/java/com/prgrms/team03linkbookbe/user/dto/UserResponse.java
+++ b/src/main/java/com/prgrms/team03linkbookbe/user/dto/UserResponse.java
@@ -1,24 +1,20 @@
 package com.prgrms.team03linkbookbe.user.dto;
 
 import com.prgrms.team03linkbookbe.user.entity.User;
-import javax.persistence.Column;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Builder
 @Getter
 public class UserResponse {
+
     private Long id;
 
     private String name;
 
     private String image;
 
-
-    public static UserResponse fromEntity(User user){
+    public static UserResponse fromEntity(User user) {
         return UserResponse.builder()
             .id(user.getId())
             .name(user.getName())

--- a/src/main/java/com/prgrms/team03linkbookbe/user/service/UserService.java
+++ b/src/main/java/com/prgrms/team03linkbookbe/user/service/UserService.java
@@ -24,7 +24,7 @@ public class UserService {
 
     public User login(String email, String credentials) {
         User user = userRepository.findByEmail(email)
-            .orElseThrow(() -> new LoginFailureException());
+            .orElseThrow(LoginFailureException::new);
         user.checkPassword(passwordEncoder, credentials);
         return user;
     }
@@ -39,14 +39,14 @@ public class UserService {
 
     public UserResponseDto findByEmail(String email) {
         return userRepository.findByEmail(email)
-            .map(user -> UserResponseDto.fromEntity(user))
-            .orElseThrow(() -> new NoDataException());
+            .map(UserResponseDto::fromEntity)
+            .orElseThrow(NoDataException::new);
     }
 
     @Transactional
-    public void updateUser (UpdateRequestDto requestDto, String email) {
+    public void updateUser(UpdateRequestDto requestDto, String email) {
         User user = userRepository.findByEmailFetchJoinInterests(email)
-            .orElseThrow(() -> new NoDataException());
+            .orElseThrow(NoDataException::new);
         user.updateUser(requestDto.getName(), requestDto.getImage(), requestDto.getIntroduce(), requestDto.getInterests());
     }
 

--- a/src/test/java/com/prgrms/team03linkbookbe/annotation/WithJwtAuth.java
+++ b/src/test/java/com/prgrms/team03linkbookbe/annotation/WithJwtAuth.java
@@ -1,0 +1,11 @@
+package com.prgrms.team03linkbookbe.annotation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import org.springframework.security.test.context.support.WithSecurityContext;
+
+@Retention(RetentionPolicy.RUNTIME)
+@WithSecurityContext(factory = WithJwtAuthSecurityContextFactory.class)
+public @interface WithJwtAuth {
+    String email();
+}

--- a/src/test/java/com/prgrms/team03linkbookbe/annotation/WithJwtAuthSecurityContextFactory.java
+++ b/src/test/java/com/prgrms/team03linkbookbe/annotation/WithJwtAuthSecurityContextFactory.java
@@ -1,0 +1,26 @@
+package com.prgrms.team03linkbookbe.annotation;
+
+import com.prgrms.team03linkbookbe.jwt.JwtAuthentication;
+import java.util.List;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+
+public class WithJwtAuthSecurityContextFactory implements WithSecurityContextFactory<WithJwtAuth> {
+
+    @Override
+    public SecurityContext createSecurityContext(WithJwtAuth annotation) {
+        String email = annotation.email();
+
+        JwtAuthentication authentication =
+            new JwtAuthentication("access-token", "refresh-token", email);
+        UsernamePasswordAuthenticationToken token =
+            new UsernamePasswordAuthenticationToken(authentication, "password",
+                List.of(new SimpleGrantedAuthority("ROLE_USER")));
+        SecurityContext context = SecurityContextHolder.getContext();
+        context.setAuthentication(token);
+        return context;
+    }
+}

--- a/src/test/java/com/prgrms/team03linkbookbe/unit/refreshtoken/controller/RefreshTokenControllerUnitTest.java
+++ b/src/test/java/com/prgrms/team03linkbookbe/unit/refreshtoken/controller/RefreshTokenControllerUnitTest.java
@@ -1,0 +1,57 @@
+package com.prgrms.team03linkbookbe.unit.refreshtoken.controller;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.prgrms.team03linkbookbe.config.WebSecurityConfigure;
+import com.prgrms.team03linkbookbe.refreshtoken.controller.RefreshTokenController;
+import com.prgrms.team03linkbookbe.refreshtoken.dto.AccessTokenResponseDto;
+import com.prgrms.team03linkbookbe.refreshtoken.service.RefreshTokenService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(
+    controllers = RefreshTokenController.class,
+    excludeFilters = {
+        @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebSecurityConfigure.class)
+    }
+)
+public class RefreshTokenControllerUnitTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private RefreshTokenService service;
+
+    String refreshToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IklsaHdhbiBMZWUiLCJpYXQiOjE1MTYyMzkwMjJ9.HjKjCVRYo5kZH1tDbFzh5HLYwEB6WTqdbFIQLTWLA6U";
+    String accessToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
+    String reissuedAccessToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6InFxIExlZSIsImlhdCI6MTUxNjIzOTAyMn0.Fs9sMsN-DQzQwlrQYrSUy-PKpFRHHk6xxzbucYmxwpM";
+
+    @Test
+    @DisplayName("액세스 토큰 재발급 테스트")
+    @WithMockUser
+    void ACCESS_TOKEN_REISSUE_TEST() throws Exception {
+        // given
+        AccessTokenResponseDto responseDto = AccessTokenResponseDto.builder()
+            .accessToken(reissuedAccessToken)
+            .build();
+        given(service.reissueAccessToken(accessToken, refreshToken)).willReturn(responseDto);
+
+        // when & then
+        mockMvc.perform(get("/api/refresh-token")
+                .header("Access-Token", accessToken)
+                .header("Refresh-Token", refreshToken))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.accessToken").value(reissuedAccessToken));
+    }
+}

--- a/src/test/java/com/prgrms/team03linkbookbe/unit/user/controller/UserControllerUnitTest.java
+++ b/src/test/java/com/prgrms/team03linkbookbe/unit/user/controller/UserControllerUnitTest.java
@@ -1,0 +1,137 @@
+package com.prgrms.team03linkbookbe.unit.user.controller;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.prgrms.team03linkbookbe.annotation.WithJwtAuth;
+import com.prgrms.team03linkbookbe.config.WebSecurityConfigure;
+import com.prgrms.team03linkbookbe.jwt.JwtAuthentication;
+import com.prgrms.team03linkbookbe.jwt.JwtAuthenticationToken;
+import com.prgrms.team03linkbookbe.user.controller.UserController;
+import com.prgrms.team03linkbookbe.user.dto.LoginRequestDto;
+import com.prgrms.team03linkbookbe.user.dto.RegisterRequestDto;
+import com.prgrms.team03linkbookbe.user.dto.UserResponseDto;
+import com.prgrms.team03linkbookbe.user.entity.User;
+import com.prgrms.team03linkbookbe.user.service.UserService;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(
+    controllers = UserController.class,
+    excludeFilters = {
+        @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebSecurityConfigure.class)
+    }
+)
+public class UserControllerUnitTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private UserService service;
+
+    @MockBean
+    private AuthenticationManager authenticationManager;
+
+    @Test
+    @DisplayName("회원가입 테스트")
+    @WithMockUser
+    void REGISTER_TEST() throws Exception {
+        // given
+        RegisterRequestDto requestDto = RegisterRequestDto.builder()
+            .email("example1@gmail.com")
+            .password("qwer1234!!")
+            .build();
+        doNothing().when(service).register(requestDto);
+
+        // when & then
+        mockMvc.perform(post("/api/users/register")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(requestDto))
+                .with(SecurityMockMvcRequestPostProcessors.csrf()))
+            .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("로그인 테스트")
+    void LOGIN_TEST() throws Exception {
+        // given
+        String email = "example1@gmail.com";
+        String password = "qwer1234!!";
+
+        User user = User.builder()
+            .build();
+
+        LoginRequestDto requestDto = LoginRequestDto.builder()
+            .email(email)
+            .password(password)
+            .build();
+
+        given(service.login(email, password)).willReturn(user);
+
+        JwtAuthenticationToken jwtAuthenticationToken = new JwtAuthenticationToken(email, password);
+        String accessToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
+        String refreshToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IklsaHdhbiBMZWUiLCJpYXQiOjE1MTYyMzkwMjJ9.HjKjCVRYo5kZH1tDbFzh5HLYwEB6WTqdbFIQLTWLA6U";
+        JwtAuthentication jwtAuthentication =
+            new JwtAuthentication(accessToken, refreshToken, email);
+        List<GrantedAuthority> roles = new ArrayList<>();
+        roles.add(new SimpleGrantedAuthority("ROLE_USER"));
+        JwtAuthenticationToken authenticated =
+            new JwtAuthenticationToken(jwtAuthentication, password, roles);
+
+        given(authenticationManager.authenticate(jwtAuthenticationToken)).willReturn(
+            authenticated);
+
+        // when & then
+        mockMvc.perform(post("/api/users/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(requestDto))
+                .with(SecurityMockMvcRequestPostProcessors.csrf()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.accessToken").value(accessToken))
+            .andExpect(jsonPath("$.refreshToken").value(refreshToken));
+    }
+
+    @Test
+    @DisplayName("개인정보 조회 테스트")
+    @WithJwtAuth(email = "example1@gmail.com")
+    void ME_TEST() throws Exception {
+        // given
+        String email = "example1@gmail.com";
+        UserResponseDto responseDto = UserResponseDto.builder()
+            .email(email)
+            .image("사용자 이미지 URL")
+            .name("닉네임")
+            .role("ROLE_USER")
+            .build();
+
+        given(service.findByEmail(email)).willReturn(responseDto);
+
+        // when & then
+        mockMvc.perform(get("/api/users/me")
+                .with(SecurityMockMvcRequestPostProcessors.csrf()))
+            .andExpect(status().isOk());
+    }
+}


### PR DESCRIPTION
## 📌 개발 내용
- resolve #31 
- User, RefreshToken 컨트롤러 단위 테스트 구현
- 테스트에서 @AuthenticationPrincipal 해결을 위한 커스텀 어노테이션 구현
<br>

## 💻  변경 내용
- 저희가 JWT 구현 과정에 authentication의 principal을 커스텀 구현해 @WithUserDetails 사용이 불가해서
- test.annotation 패키지에 `@WithJwtAuth`를 구현했습니다.
- <img width="809" alt="스크린샷 2022-08-02 오후 11 03 16" src="https://user-images.githubusercontent.com/60428537/182393995-4f87faeb-5439-494d-a7e4-9f28c7be1e37.png">
- 위와 같이 `@AuthenticationPrincipal` 로 `JwtAuthentication` 의 email을 사용하는 컨트롤러 메소드를 테스트할때 사용하시면 될 것 같습니다.
- <img width="348" alt="스크린샷 2022-08-02 오후 11 05 04" src="https://user-images.githubusercontent.com/60428537/182394327-ece219f6-3fa2-4519-aa51-f6e98a2b0e24.png">

- 위와 같이 @WithJwtAuth(email = "뭐시기")로 사용하시면 됩니다.
<br>

## ✅ PR Point
- 다들 컨트롤러 테스트 작성에서 애로사항이 있으실 것 같아 단위 테스트 먼저 PR 할게요...!            
<br>
