### PR TITLE
[SETTING] CI/CD 플로우 수정 : PR 발행 → build 만 실행, main branch push → Deploy 실행

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,44 @@
+name: Spring Boot & Gradle CI
+
+on:
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      # 기본 체크아웃
+      - name: checkout
+        uses: actions/checkout@v3
+
+      # JDK version 설정
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+
+      # 설정 파일 생성 및 write
+      - name: make env file
+        run: |
+          # 설정 파일 디렉토리로 이동
+          cd ./src/main/resources
+          
+          # application-database.yaml 파일 생성
+          touch ./application-database.yaml
+
+          # GitHub-Actions 에서 설정한 값을 application-database.yaml 파일에 쓰기
+          echo "${{ secrets.DATABASE }}" >> ./application-database.yaml
+          
+          # application-jwt.yaml 파일 생성
+          touch ./application-jwt.yaml
+          
+          # GitHub-Actions 에서 설정한 값을 application-jwt.yaml 파일에 쓰기
+          echo "${{ secrets.JWT }}" >> ./application-jwt.yaml
+
+        shell: bash
+
+      # Gradle build
+      - name: Build with Gradle
+        run: ./gradlew bootJar

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,16 +1,7 @@
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-# This workflow will build a Java project with Gradle and cache/restore any dependencies to improve the workflow execution time
-# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle
-
-name: Java CI with Gradle
+name: Spring Boot & Gradle & NGINX & Docker CD
 
 on:
   push:
-    branches: [ "main" ]
-  pull_request:
     branches: [ "main" ]
 
 permissions:
@@ -18,24 +9,25 @@ permissions:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
     steps:
+      # 기본 체크아웃
       - name: checkout
         uses: actions/checkout@v3
 
+      # JDK version 설정
       - name: Set up JDK 11
         uses: actions/setup-java@v3
         with:
           java-version: '11'
           distribution: 'temurin'
 
+      # 설정 파일 생성 및 write
       - name: make env file
         run: |
-          ## create env file
+          # 설정 파일 디렉토리로 이동
           cd ./src/main/resources
-
+          
           # application-database.yaml 파일 생성
           touch ./application-database.yaml
 
@@ -50,17 +42,18 @@ jobs:
 
         shell: bash
 
-
+      # Gradle build
       - name: Build with Gradle
         run: ./gradlew bootJar
 
-
+      # Docker Image 빌드
       - name: Build Docker Image
         run: |
           docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}
           docker build -t ${{ secrets.DOCKER_USERNAME }}/linkbook-web .
           docker push ${{ secrets.DOCKER_USERNAME }}/linkbook-web
 
+      # 서버에서 어플리케이션 실행 (with Docker)
       - name: EC2 Docker Run
         uses: appleboy/ssh-action@master
         with:
@@ -72,14 +65,14 @@ jobs:
             docker rmi ${{ secrets.DOCKER_USERNAME }}/linkbook-web
             docker pull ${{ secrets.DOCKER_USERNAME }}/linkbook-web
             docker run -d --rm --name server -p 8080:8080 ${{ secrets.DOCKER_USERNAME }}/linkbook-web
-            
+
+      # Github Action 성공 여부 Slack 알림 전송
       - name: action-slack
         uses: 8398a7/action-slack@v3.12.0
         with:
           status: ${{ job.status }}
-          author_name: Github Action # default: 8398a7@action-slack
+          author_name: Github Action
           fields: message,commit,author,eventName,workflow,took
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }} # required
-        if: always() # Pick up events even if the job fails or is canceled.
-
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        if: always()


### PR DESCRIPTION
## 📌 개발 내용
- resolve #37 
> CI/CD 플로우 수정
   - PR 올리면 CI/CD 는 build 까지만 체크, merge 되면 그 때 Deploy 되도록
> 수정 이유
   - 현재 구조 : PR 이 올라올 때 마다, 그리고 PR 올린 코드를 수정할 때마다 코드 Deploy가 이루어진다. 
   - 내 코드가 잘 배포 되었는지 직접 서버에서 확인하기 위해 ec2 접속하는 사이, 누가 PR 을 올리거나 PR 에 수정사항을 push 하면
   그 사람 코드가 서버에 배포되어 올라가버림. 내 코드 돌려줘요 ㅠㅠ
<br>

## 💻  변경 내용
- `github-action.yml` 스크립트 → `build.yml` 과 `deploy.yml` 파일로 분리
<br>

## ✅ PR Point
- 해당 PR은 self-approve 처리하겠습니다!
   - 현재 로컬 서버 개발에 영향을 미치지 않는 로직이며, 기존 CI/CD Flow 의 내용을 수정하지 않고 단순히 구조만 분리한 코드이므로
   self-approve 해도 크게 문제 없을 것 같습니다.
   - 혹시 merge 이후 문제가 발생하는 경우 다시 Rollback 조치해두겠습니다!! 🙏🏻                       
<br>
