### PR TITLE
[REFACTOR] 태그로 폴더 검색 리팩토링

### DIFF
--- a/src/main/java/com/prgrms/team03linkbookbe/folder/repository/FolderRepository.java
+++ b/src/main/java/com/prgrms/team03linkbookbe/folder/repository/FolderRepository.java
@@ -35,11 +35,19 @@ public interface FolderRepository extends JpaRepository<Folder, Long> {
         countQuery = "SELECT count(f) FROM Folder f")
     Page<Folder> findAllByTitle(Boolean isPrivate, Pageable pageable, String title);
 
-    @Query(value = "SELECT DISTINCT f FROM Folder f JOIN FETCH f.user JOIN FETCH f.folderTags ft JOIN ft.tag t JOIN t.rootTag rt ON rt.name = :rootTag WHERE f.isPrivate = false",
+    @Query(value = "SELECT DISTINCT f FROM Folder f " +
+        "JOIN FETCH f.user JOIN FETCH f.folderTags ft " +
+        "WHERE f.isPrivate = false AND f.id IN " +
+        "(SELECT subf.id FROM Folder subf JOIN subf.folderTags subft JOIN subft.tag subt JOIN subt.rootTag subrt " +
+        "ON subrt.name = :rootTag)",
         countQuery = "SELECT count(f) FROM Folder f")
     Page<Folder> findByRootTag(RootTagCategory rootTag, Pageable pageable);
 
-    @Query(value = "SELECT DISTINCT f FROM Folder f JOIN FETCH f.user JOIN FETCH f.folderTags ft JOIN ft.tag t ON t.name = :tag WHERE f.isPrivate = false",
+    @Query(value = "SELECT DISTINCT f FROM Folder f " +
+        "JOIN FETCH f.user JOIN FETCH f.folderTags ft " +
+        "WHERE f.isPrivate = false AND f.id IN " +
+        "(SELECT subf.id FROM Folder subf JOIN subf.folderTags subft JOIN subft.tag subt " +
+        "ON subt.name = :tag)",
         countQuery = "SELECT count(f) FROM Folder f")
     Page<Folder> findByTag(TagCategory tag, Pageable pageable);
 }

--- a/src/main/java/com/prgrms/team03linkbookbe/folderTag/repository/FolderTagRepository.java
+++ b/src/main/java/com/prgrms/team03linkbookbe/folderTag/repository/FolderTagRepository.java
@@ -2,9 +2,7 @@ package com.prgrms.team03linkbookbe.folderTag.repository;
 
 import com.prgrms.team03linkbookbe.folder.entity.Folder;
 import com.prgrms.team03linkbookbe.folderTag.entity.FolderTag;
-import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 
 public interface FolderTagRepository extends JpaRepository<FolderTag, Long> {
 
@@ -16,7 +14,4 @@ public interface FolderTagRepository extends JpaRepository<FolderTag, Long> {
 //
 //    @Query("SELECT DISTINCT ft.folder FROM FolderTag ft JOIN FETCH ft.folder JOIN FETCH ft.tag WHERE ft.tag = :sub order by ft.folder.createdAt DESC ")
 //    Page<FolderTag> findFolderTagByRootTagOrderByCreatedAt(TagCategory sub);
-
-    @Query("SELECT DISTINCT ft FROM FolderTag ft JOIN FETCH ft.tag WHERE ft.folder.id = :folderId")
-    List<FolderTag> findByFolderId(Long folderId);
 }


### PR DESCRIPTION
## 📌 개발 내용
- resolve #90 
- 태그로 검색 시 쿼리 2개 사용하는 문제
<br>

## 💻  변경 내용
- 서브 쿼리로 해당 태그 가진 folder id 찾은 뒤 해당 folder id를 가지고 isPrivate false인 폴더 조회(User, FolderTag fetch join)
<br>
